### PR TITLE
Fix error when parsing variables with '=' sign in the value

### DIFF
--- a/j2parse.py
+++ b/j2parse.py
@@ -41,8 +41,8 @@ if options.file:
 
 if options.environment:
     for e in options.environment:
-        (var, value) = e.split('=')
-        environment[var] = value
+        fields = e.split('=')
+        environment[fields[0]] = "=".join(fields[1:])
 
 result = render(tpl_file, environment)
 


### PR DESCRIPTION
There was a minor issue when you parse base64 encoded string. I had to fix it.